### PR TITLE
Update build.yml, enable rpc for windows cuda builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -857,7 +857,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DGGML_CUDA=ON -DBUILD_SHARED_LIBS=ON
+          cmake .. -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DGGML_CUDA=ON -DBUILD_SHARED_LIBS=ON -DGGML_RPC=ON
           cmake --build . --config Release -j $((${env:NUMBER_OF_PROCESSORS} - 1)) -t ggml
           cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS}
 


### PR DESCRIPTION
enable rpc for windows cuda builds

without GGML_RPC set, llama-server ignores --rpc arguments, also it won't build cuda enabled rpc-server.

tested with windows llama-server + linux rpc-servers, most models I tested works, only mixtral quant crashes with

ggml/src/ggml-rpc.cpp:893: GGML_ASSERT(tensor->data + tensor_size >= tensor->data) failed

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High
